### PR TITLE
Fixed `Table has reached its quota of 1 reader(s)` error

### DIFF
--- a/src/main/scala/com/singlestore/spark/AggregatorParallelReadListener.scala
+++ b/src/main/scala/com/singlestore/spark/AggregatorParallelReadListener.scala
@@ -68,8 +68,10 @@ class AggregatorParallelReadListener(applicationId: String) extends SparkListene
             rddInfos.get(rddInfo.id)
           )
           .foreach(singleStoreRDDInfo => {
-            val stageId   = stageSubmitted.stageInfo.stageId
-            val tableName = JdbcHelpers.getResultTableName(applicationId, stageId, rddInfo.id)
+            val stageId       = stageSubmitted.stageInfo.stageId
+            val attemptNumber = stageSubmitted.stageInfo.attemptNumber()
+            val tableName =
+              JdbcHelpers.getResultTableName(applicationId, stageId, rddInfo.id, attemptNumber)
 
             // Create connection and save it in the map
             val conn =
@@ -97,8 +99,10 @@ class AggregatorParallelReadListener(applicationId: String) extends SparkListene
   override def onStageCompleted(stageCompleted: SparkListenerStageCompleted): Unit = {
     stageCompleted.stageInfo.rddInfos.foreach(rddInfo => {
       if (rddInfo.name == "SinglestoreRDD") {
-        val stageId   = stageCompleted.stageInfo.stageId
-        val tableName = JdbcHelpers.getResultTableName(applicationId, stageId, rddInfo.id)
+        val stageId       = stageCompleted.stageInfo.stageId
+        val attemptNumber = stageCompleted.stageInfo.attemptNumber()
+        val tableName =
+          JdbcHelpers.getResultTableName(applicationId, stageId, rddInfo.id, attemptNumber)
 
         connectionsMap.synchronized(
           connectionsMap

--- a/src/main/scala/com/singlestore/spark/JdbcHelpers.scala
+++ b/src/main/scala/com/singlestore/spark/JdbcHelpers.scala
@@ -413,8 +413,11 @@ object JdbcHelpers extends LazyLogging {
     }
   }
 
-  def getResultTableName(applicationId: String, stageId: Int, rddId: Int): String = {
-    s"rt_${applicationId.replace("-", "")}_${stageId}_${rddId}"
+  def getResultTableName(applicationId: String,
+                         stageId: Int,
+                         rddId: Int,
+                         attemptNumber: Int): String = {
+    s"rt_${applicationId.replace("-", "")}_${stageId}_${rddId}_${attemptNumber}"
   }
 
   def getCreateResultTableQuery(tableName: String,

--- a/src/main/scala/com/singlestore/spark/SinglestoreRDD.scala
+++ b/src/main/scala/com/singlestore/spark/SinglestoreRDD.scala
@@ -100,7 +100,10 @@ case class SinglestoreRDD(query: String,
 
     conn = SinglestoreConnectionPool.getConnection(partition.connectionInfo)
     if (aggregatorParallelReadUsed) {
-      val tableName = JdbcHelpers.getResultTableName(applicationId, context.stageId(), id)
+      val tableName = JdbcHelpers.getResultTableName(applicationId,
+                                                     context.stageId(),
+                                                     id,
+                                                     context.attemptNumber())
 
       stmt =
         conn.prepareStatement(JdbcHelpers.getSelectFromResultTableQuery(tableName, partition.index))


### PR DESCRIPTION
Summary:
In the case when job failed and `ReadFromAggregators` was used, there is a chance that executors will try to read result before onStageCompleted function is called. In this case, reading task will read from the old table and get `Table has reached its quota of 1 reader(s)` error .
I was not able to reproduce this scenario neither locally neither on real spark cluster. Changed table name to be unique for each stage attempt. As a result of this change, this error shoudn't appear in any case. **Design doc/spec**:
**Docs impact**: none
**Preliminary Reviewer(s)**:
**Final Reviewer**:
Test Plan:

Reviewers:
pmishchenko-ua, adam
CC:

Jira issues:
PLAT-6477