### PR TITLE
Fixed bug which caused reading from the wrong result table

### DIFF
--- a/src/main/scala/com/singlestore/spark/SinglestoreRDD.scala
+++ b/src/main/scala/com/singlestore/spark/SinglestoreRDD.scala
@@ -104,7 +104,7 @@ case class SinglestoreRDD(query: String,
       val tableName = JdbcHelpers.getResultTableName(applicationId,
                                                      context.stageId(),
                                                      id,
-                                                     context.attemptNumber(),
+                                                     context.stageAttemptNumber(),
                                                      randHex)
 
       stmt =


### PR DESCRIPTION
When the result table is created - the stage attempt number is used.
But when it is read - a task attempt number is used (which is 0 for non-materialized parallel read).